### PR TITLE
Handle missing tenant when accessing the root route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Tenant;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\GuestController;
 use App\Http\Controllers\ScanController;
@@ -16,8 +15,16 @@ use App\Http\Controllers\ScanController;
 |
 */
 
-Route::get('/', function() {
-	return Tenant::current()->name == "landlord" ? redirect()->to('super') : redirect()->to('admin');
+Route::get('/', function () {
+    $currentTenant = tenant();
+
+    if (! $currentTenant) {
+        return redirect()->to('super');
+    }
+
+    return $currentTenant->name === 'landlord'
+        ? redirect()->to('super')
+        : redirect()->to('admin');
 });
 
 Route::middleware('tenant')->group(function() {


### PR DESCRIPTION
## Summary
- prevent the root route from calling Tenant::current() when no tenant is active
- redirect requests without a current tenant directly to the super panel
- keep existing tenant routing for landlord and tenant domains

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e926110b188331b6d6521aa91ae915