### PR TITLE
Fix tenant edit artisan command formatting

### DIFF
--- a/app/Filament/Resources/Landlord/TenantResource/Pages/EditTenant.php
+++ b/app/Filament/Resources/Landlord/TenantResource/Pages/EditTenant.php
@@ -172,10 +172,15 @@ class EditTenant extends EditRecord
 			Log::info('Database created successfully');
 			
 			// Artisan::call with correct syntax
-			Artisan::call('tenants:artisan', [
-				'--tenant' => $this->record->id,
-				'artisanCommand' => '"migrate:fresh --path=database/migrations/tenant --database=tenant"'
-			]);
+                        Artisan::call('tenants:artisan', [
+                                '--tenant' => $this->record->id,
+                                'artisanCommand' => 'migrate:fresh --path=database/migrations/tenant --database=tenant'
+                        ]);
+
+                        Artisan::call('tenants:artisan', [
+                                '--tenant' => $this->record->id,
+                                'artisanCommand' => 'db:seed --class=TenantDatabaseSeeder'
+                        ]);
 			
 			// Redirect to the tenant's dashboard
 			$this->redirect($this->getResource()::getUrl('index'));


### PR DESCRIPTION
## Summary
- align the tenants:artisan migration call on tenant edit with the create flow
- run the tenant database seeder after migrations when editing to keep environments consistent

## Testing
- not run (environment lacks configured tenant data)


------
https://chatgpt.com/codex/tasks/task_e_68e936048f848331ac3a9f79c841fb42