### PR TITLE
Use slugged subdomains for tenant domains

### DIFF
--- a/app/Filament/Resources/Landlord/TenantResource.php
+++ b/app/Filament/Resources/Landlord/TenantResource.php
@@ -33,7 +33,7 @@ class TenantResource extends Resource
                     ->live(onBlur: true)
                     ->afterStateUpdated(function (Forms\Get $get, Forms\Set $set, ?string $state) {
                         if (! $get('is_domain_manually_changed')) {
-                            $subdomain = Str::snake($state);
+                            $subdomain = Str::slug($state);
                             $set('domain', $subdomain);
                         }
                         if (! $get('is_database_manually_changed')) {
@@ -66,7 +66,7 @@ class TenantResource extends Resource
                     ->dehydrated(true) // Always include in form submission
                     ->helperText(function (Forms\Get $get) {
                         if ($get('domain_type') === 'subdomain') {
-                            return 'Auto-generated: ' . Str::snake($get('name')) . '.' . config('app.domain');
+                            return 'Auto-generated: ' . Str::slug($get('name')) . '.' . config('app.domain');
                         }
                         return 'Enter your custom domain';
                     })

--- a/app/Filament/Resources/Landlord/TenantResource/Pages/CreateTenant.php
+++ b/app/Filament/Resources/Landlord/TenantResource/Pages/CreateTenant.php
@@ -19,9 +19,9 @@ class CreateTenant extends CreateRecord
     {
         // Format subdomain based on domain_type
         if ($data['domain_type'] === 'subdomain') {
-			$sub = env('APP_DOMAIN');
+            $sub = env('APP_DOMAIN');
             // Store only the subdomain part, not the full domain
-            $data['domain'] = Str::snake($data['domain']).'.' . $sub;
+            $data['domain'] = Str::slug($data['domain']) . '.' . $sub;
         }
         
         // Ensure database name follows the standard format

--- a/app/Filament/Resources/Landlord/TenantResource/Pages/EditTenant.php
+++ b/app/Filament/Resources/Landlord/TenantResource/Pages/EditTenant.php
@@ -20,7 +20,7 @@ class EditTenant extends EditRecord
         // Format subdomain based on domain_type
         if ($data['domain_type'] === 'subdomain') {
             // Store only the subdomain part, not the full domain
-            $data['domain'] = Str::snake($data['domain']);
+            $data['domain'] = Str::slug($data['domain']);
         }
         
         // Ensure database name follows the standard format


### PR DESCRIPTION
## Summary
- update tenant form auto-fill to slug subdomains with hyphens
- ensure tenant creation and editing normalize domains with the same slug helper

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e93603c3e0833198ac7f4bd2788f7b