### PR TITLE
Fix tenant domain formatter to avoid duplicate base domain

### DIFF
--- a/app/Filament/Resources/Landlord/TenantResource.php
+++ b/app/Filament/Resources/Landlord/TenantResource.php
@@ -110,14 +110,29 @@ class TenantResource extends Resource
                     ->searchable()
                     ->label('Domain')
                     ->formatStateUsing(function ($state, $record = null) {
-                        if (!$record || !$state) {
+                        if (! $record || blank($state)) {
                             return '';
                         }
-                        
-                        $domainParts = explode('.', $state);
-                        if (count($domainParts) <= 2) {
-                            return $state . '.' . config('app.domain');
+
+                        $state = trim($state);
+                        $baseDomain = config('app.domain');
+
+                        if (! $baseDomain) {
+                            return $state;
                         }
+
+                        if ($record->domain_type !== 'subdomain') {
+                            return $state;
+                        }
+
+                        if (Str::endsWith($state, $baseDomain)) {
+                            return $state;
+                        }
+
+                        if (! Str::contains($state, '.')) {
+                            return $state . '.' . $baseDomain;
+                        }
+
                         return $state;
                     }),
                 Tables\Columns\TextColumn::make('custom_domain')


### PR DESCRIPTION
## Summary
- adjust the landlord tenant domain column formatter so the base domain is only appended when needed and custom domains are left unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e93608c35c8331b733fc0a7087b137