### PR TITLE
Capture landlord-provided tenant admin credentials

### DIFF
--- a/app/Filament/Resources/Landlord/TenantResource.php
+++ b/app/Filament/Resources/Landlord/TenantResource.php
@@ -90,6 +90,34 @@ class TenantResource extends Resource
                     ->helperText(function (Forms\Get $get) {
                         return 'Auto-generated: ' . Str::snake($get('name')) . '_db';
                     }),
+
+                Forms\Components\Section::make('Administrator')
+                    ->description('Set up the initial administrator for this tenant.')
+                    ->schema([
+                        Forms\Components\TextInput::make('admin_name')
+                            ->label('Admin Name')
+                            ->required(fn (string $context) => $context === 'create')
+                            ->maxLength(255)
+                            ->dehydrated(false),
+                        Forms\Components\TextInput::make('admin_email')
+                            ->label('Admin Email')
+                            ->email()
+                            ->required(fn (string $context) => $context === 'create')
+                            ->maxLength(255)
+                            ->dehydrated(false),
+                        Forms\Components\TextInput::make('admin_password')
+                            ->label('Admin Password')
+                            ->password()
+                            ->required(fn (string $context) => $context === 'create')
+                            ->confirmed()
+                            ->dehydrated(false),
+                        Forms\Components\TextInput::make('admin_password_confirmation')
+                            ->label('Confirm Password')
+                            ->password()
+                            ->required(fn (string $context) => $context === 'create')
+                            ->dehydrated(false),
+                    ])
+                    ->columns(2),
             ]);
     }
 

--- a/app/Filament/Resources/Landlord/TenantResource/Pages/CreateTenant.php
+++ b/app/Filament/Resources/Landlord/TenantResource/Pages/CreateTenant.php
@@ -2,21 +2,40 @@
 
 namespace App\Filament\Resources\Landlord\TenantResource\Pages;
 
-use DigitalOceanV2;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Artisan;
 use App\Filament\Resources\Landlord\TenantResource;
+use App\Models\UserTenant;
 use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class CreateTenant extends CreateRecord
 {
     protected static string $resource = TenantResource::class;
 
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $adminCredentials = [];
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
+        $this->adminCredentials = [
+            'name' => $data['admin_name'] ?? null,
+            'email' => $data['admin_email'] ?? null,
+            'password' => $data['admin_password'] ?? null,
+        ];
+
+        unset(
+            $data['admin_name'],
+            $data['admin_email'],
+            $data['admin_password'],
+            $data['admin_password_confirmation'],
+        );
+
         // Format subdomain based on domain_type
         if ($data['domain_type'] === 'subdomain') {
             $sub = env('APP_DOMAIN');
@@ -30,114 +49,62 @@ class CreateTenant extends CreateRecord
         return $data;
     }
 
-	//after creating a tenant, redirect to the tenant's dashboard
-	protected function afterCreate(): void
-	{
-		try{
-			//goto createTenant;
-			//client
-			/*$client = new DigitalOceanV2\Client();
-			$client->authenticate(config('services.digitalocean.token'));
+    //after creating a tenant, redirect to the tenant's dashboard
+    protected function afterCreate(): void
+    {
+        try {
+            //createTenant:
+            //create the database
+            DB::statement('CREATE DATABASE IF NOT EXISTS ' . $this->record->database);
 
-			$domainRecord = $client->domainRecord();
-			$records = $domainRecord->getAll(config('services.digitalocean.domain'));
-			
-			// Get the subdomain from the domain field
-			$subdomain = $this->record->domain;
-			$sub = env('APP_DOMAIN');
-			$subdomain = str_replace('.' . $sub, '', $subdomain);
-			$recordExists = false;
-			
-			// Check if the subdomain record exists
-			foreach ($records as $record) {
-				Log::info('Record Name: ' . $record->name);
-				if ($record->name == $subdomain) {
-					$recordExists = true;
-					break;
-				}
-			}
+            //call artisan command to create the database
+            // Artisan::call with correct syntax
+            Log::info([
+                'artisanCommand' => 'migrate:fresh --path=database/migrations/tenant --database=tenant',
+                '--tenant' => $this->record->id,
+            ]);
+            Artisan::call('tenants:artisan', [
+                'artisanCommand' => 'migrate:fresh --path=database/migrations/tenant --database=tenant',
+                '--tenant' => $this->record->id,
+            ]);
+            Log::info([
+                'artisanCommand' => 'db:seed --class=TenantDatabaseSeeder',
+                '--tenant' => $this->record->id,
+            ]);
+            //php artisan tenants:artisan "migrate --database=tenant --seed"
+            Artisan::call('tenants:artisan', [
+                'artisanCommand' => 'db:seed --class=TenantDatabaseSeeder',
+                '--tenant' => $this->record->id,
+            ]);
+            Log::info('permission:cache-reset');
+            //php artisan permission:cache-reset
+            Artisan::call('permission:cache-reset');
+            app()->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
 
-			// Create or update the subdomain record
-			if (!$recordExists) {
-				$domainRecord->create(config('services.digitalocean.domain'), 'A', $subdomain, config('services.digitalocean.ip'));
-			}
-			
-			// If this tenant has a custom domain, create a CNAME record that points to the subdomain
-			if ($this->record->domain_type === 'domain' && !empty($this->record->custom_domain)) {
-				// Create a CNAME record for the custom domain pointing to the subdomain
-				// First we need to determine the full subdomain
-				$fullSubdomain = $subdomain . '.' . config('services.digitalocean.domain');
-				
-				// For simplicity, we'll assume the custom domain doesn't exist in DO
-				// In a real application, you might want to check and update existing records
-				try {
-					// Get the domain and subdomain parts from the custom domain
-					$customDomainParts = explode('.', $this->record->custom_domain);
-					$customSubdomain = $customDomainParts[0];
-					$customDomain = implode('.', array_slice($customDomainParts, 1));
-					
-					// Check if we can manage this domain in DO
-					$domainExists = false;
-					try {
-						$domains = $client->domain()->getAll();
-						foreach ($domains as $domain) {
-							if ($domain->name === $customDomain) {
-								$domainExists = true;
-								break;
-							}
-						}
-						
-						if ($domainExists) {
-							// Create CNAME record in the custom domain pointing to our subdomain
-							$domainRecord->create($customDomain, 'CNAME', $customSubdomain, $fullSubdomain);
-							Log::info("Created CNAME record for {$this->record->custom_domain} pointing to {$fullSubdomain}");
-						} else {
-							Log::warning("Could not create CNAME record - domain {$customDomain} is not managed in DigitalOcean");
-						}
-					} catch (\Exception $e) {
-						Log::error("Error creating CNAME record: " . $e->getMessage());
-					}
-				} catch (\Exception $e) {
-					Log::error("Error processing custom domain: " . $e->getMessage());
-				}
-			}*/
-			//createTenant:
-			//create the database
-			DB::statement('CREATE DATABASE IF NOT EXISTS ' . $this->record->database);
-			
-			//call artisan command to create the database
-			// Artisan::call with correct syntax
-			Log::info([
-				'artisanCommand' => 'migrate:fresh --path=database/migrations/tenant --database=tenant',
-				'--tenant' => $this->record->id
-			]);
-			Artisan::call('tenants:artisan', [
-				'artisanCommand' => 'migrate:fresh --path=database/migrations/tenant --database=tenant',
-				'--tenant' => $this->record->id
-			]);
-			Log::info([
-				'artisanCommand' => 'db:seed --class=TenantDatabaseSeeder',
-				'--tenant' => $this->record->id
-			]);
-			//php artisan tenants:artisan "migrate --database=tenant --seed"
-			Artisan::call('tenants:artisan', [
-				'artisanCommand' => 'db:seed --class=TenantDatabaseSeeder',
-				'--tenant' => $this->record->id
-			]);
-			Log::info("permission:cache-reset");
-			//php artisan permission:cache-reset
-			Artisan::call('permission:cache-reset');
-			app()->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
-			//$this->redirect($this->getResource()::getUrl('index'));
-		}catch (\Exception $e) {
-			Log::error('Error creating tenant: ' . $e->getMessage());
-		}
-	}
+            $adminData = $this->adminCredentials;
 
-	protected function getActions(): array
-	{
-		return [
-			Actions\CreateAction::make(),
-		];
-	}
+            if (! blank($adminData['email']) && ! blank($adminData['password'])) {
+                $this->record->run(function () use ($adminData) {
+                    $user = UserTenant::create([
+                        'name' => $adminData['name'] ?? $adminData['email'],
+                        'email' => $adminData['email'],
+                        'password' => Hash::make($adminData['password']),
+                    ]);
+
+                    $user->assignRole('Manager');
+                });
+            }
+
+            $this->adminCredentials = [];
+        } catch (\Exception $e) {
+            Log::error('Error creating tenant: ' . $e->getMessage());
+        }
+    }
+
+    protected function getActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
 }

--- a/database/seeders/TenantDatabaseSeeder.php
+++ b/database/seeders/TenantDatabaseSeeder.php
@@ -4,18 +4,13 @@ namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Spatie\Permission\Exceptions\PermissionAlreadyExists;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Database\Seeder;
-use App\Models\UserTenant as User;
 use App\Models\Guest;
 use App\Models\Meal;
 use App\Models\Room;
-use App\Models\Tenant;
 use App\Models\Consumable;
-use App\Models\MealRecord;
 use App\Models\Role;
 use App\Models\Permission;
-use App\Models\ModelHasRole;
 use Illuminate\Support\Facades\Log;
 
 class TenantDatabaseSeeder extends Seeder
@@ -209,8 +204,6 @@ class TenantDatabaseSeeder extends Seeder
 			],
 		 ]);
         
-		 // Create default admin user
-		 $this->createAdminUser();
     }
     
     /**
@@ -361,22 +354,4 @@ class TenantDatabaseSeeder extends Seeder
         $scanner->givePermissionTo($scannerPermissions);
     }
     
-    /**
-     * Create default admin user
-     */
-    private function createAdminUser()
-    {
-        $user = User::create([
-            'name' => 'Admin User',
-            'email' => 'admin@example.com',
-            'password' => bcrypt('password')
-        ]);
-        
-		// Assign the super-admin role to the user
-		$mHR = ModelHasRole::create([
-			'role_id' => 1,
-			'model_type' => 'App\Models\UserTenant',
-			'model_id' => $user->id,
-		]);
-    }
 }


### PR DESCRIPTION
## Summary
- add an administrator section to the tenant form for landlord-provided credentials without persisting them to the landlord database
- stash the supplied admin credentials during tenant creation to provision a tenant-scoped user with the Manager role after migrations
- remove the default admin seeder so the landlord-supplied account becomes the initial administrator

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9ef86629483319fda3f81564b218a