### PR TITLE
Add tenant shift report page

### DIFF
--- a/app/Filament/Pages/Tenant/ShiftReport.php
+++ b/app/Filament/Pages/Tenant/ShiftReport.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Pages\Tenant;
+
+use Filament\Pages\Page;
+use Illuminate\Support\Facades\Auth;
+
+class ShiftReport extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document';
+
+    protected static ?string $navigationLabel = 'Shift Reports';
+
+    protected static ?string $navigationGroup = 'Property';
+
+    protected static ?string $title = 'Shift Reports';
+
+    protected static ?string $slug = 'shift-reports';
+
+    protected static string $view = 'filament.pages.tenant.shift-report';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public static function canAccess(): bool
+    {
+        if (! Auth::guard('tenant')->check()) {
+            return false;
+        }
+
+        return Auth::guard('tenant')->user()->can('view daily-report');
+    }
+
+    public function getHeading(): string
+    {
+        return 'Daily Shift Report';
+    }
+
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\Tenant\ShiftReport;
 use App\Http\Middleware\FilamentPermissionMiddleware;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -37,6 +38,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages/Tenant'), for: 'App\\Filament\\Pages\\Tenant')
             ->pages([
                 Pages\Dashboard::class,
+                ShiftReport::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([

--- a/resources/views/filament/pages/tenant/shift-report.blade.php
+++ b/resources/views/filament/pages/tenant/shift-report.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        @livewire(\App\Filament\Resources\Tenant\DailyReportWidget::class)
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- add a tenant ShiftReport Filament page that displays the DailyReportWidget and restricts access to users with daily report permissions
- register the new page with the admin panel so it appears under the Property navigation group
- provide a dedicated page view that renders the existing DailyReport widget for date-based report submissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f37e6e90808331900042d4e6300c8e