### PR TITLE
Rename tenant access and meal terminology

### DIFF
--- a/app/Filament/Resources/Tenant/ActivityRecordResource.php
+++ b/app/Filament/Resources/Tenant/ActivityRecordResource.php
@@ -77,10 +77,10 @@ class ActivityRecordResource extends Resource
                 Tables\Columns\TextColumn::make('activity_type')
                     ->label('Type')
                     ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'Check-In' => 'success',
-                        'Guest Request' => 'warning',
-                        'Meal Record' => 'info',
+                    ->color(fn (string $state): string => match (true) {
+                        in_array($state, ['Access', 'Check-In', 'Check-Out']) => 'success',
+                        $state === 'Guest Request' => 'warning',
+                        in_array($state, ['Meal', 'Meal Record']) => 'info',
                         default => 'gray',
                     })
                     ->sortable(),
@@ -123,9 +123,9 @@ class ActivityRecordResource extends Resource
                 Tables\Filters\SelectFilter::make('activity_type')
                     ->label('Activity Type')
                     ->options([
-                        'Check-In' => 'Check-In/Out',
+                        'Access' => 'Access',
                         'Guest Request' => 'Guest Request',
-                        'Meal Record' => 'Meal Record',
+                        'Meal' => 'Meal',
                     ]),
 
                 Tables\Filters\SelectFilter::make('status')
@@ -160,7 +160,7 @@ class ActivityRecordResource extends Resource
                     ->visible(fn () => Auth::guard('tenant')->check() && Auth::guard('tenant')->user()->can('create guest-request')),
 
                 Tables\Actions\Action::make('create_meal')
-                    ->label('New Meal Record')
+                    ->label('New Meal')
                     ->icon('heroicon-o-cake')
                     ->color('info')
                     ->url(route('filament.admin.resources.tenant.meal-records.create'))
@@ -199,7 +199,7 @@ class ActivityRecordResource extends Resource
         // Create union query using raw SQL wrapped in a proper Eloquent builder
         $checkInsQuery = CheckIn::query()
             ->select([
-                'check_ins.activity_type as activity_type',
+                DB::raw("'Access' as activity_type"),
                 'check_ins.id',
                 'check_ins.guest_id',
                 'check_ins.room_id',
@@ -247,7 +247,7 @@ class ActivityRecordResource extends Resource
 
         $mealRecordsQuery = MealRecord::query()
             ->select([
-                'meal_records.activity_type as activity_type',
+                DB::raw("'Meal' as activity_type"),
                 'meal_records.id',
                 'meal_records.guest_id',
                 'meal_records.room_id',

--- a/app/Filament/Resources/Tenant/MealRecordResource.php
+++ b/app/Filament/Resources/Tenant/MealRecordResource.php
@@ -28,9 +28,9 @@ class MealRecordResource extends Resource
 
     protected static ?string $navigationGroup = 'Guest Requests';
 
-    protected static ?string $modelLabel = 'Meal Record';
+    protected static ?string $modelLabel = 'Meal';
 
-    protected static ?string $pluralModelLabel = 'Meal Records';
+    protected static ?string $pluralModelLabel = 'Meals';
 
     public static function form(Form $form): Form
     {
@@ -126,16 +126,16 @@ class MealRecordResource extends Resource
                 Tables\Actions\EditAction::make()
                     ->disabled(fn (): bool => ! Auth::guard('tenant')->user()->can('update meal-record'))
                     ->tooltip(fn (Tables\Actions\EditAction $action): string => $action->isDisabled()
-                        ? 'You don\'t have permission to edit meal records'
-                        : 'Edit this meal record'),
+                        ? 'You don\'t have permission to edit meals'
+                        : 'Edit this meal'),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make()
                         ->disabled(fn (): bool => ! Auth::guard('tenant')->user()->can('delete meal-record'))
                         ->tooltip(fn (Tables\Actions\DeleteBulkAction $action): string => $action->isDisabled()
-                            ? 'You don\'t have permission to delete meal records'
-                            : 'Delete selected meal records'),
+                            ? 'You don\'t have permission to delete meals'
+                            : 'Delete selected meals'),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/Tenant/TransitResource.php
+++ b/app/Filament/Resources/Tenant/TransitResource.php
@@ -30,9 +30,9 @@ class TransitResource extends Resource
 
     protected static ?string $navigationGroup = 'Guest Requests';
 
-    protected static ?string $modelLabel = 'In/Out Record';
+    protected static ?string $modelLabel = 'Access Record';
 
-    protected static ?string $pluralModelLabel = 'In/Out Records';
+    protected static ?string $pluralModelLabel = 'Access Records';
 
     // Permission control for resource access
     public static function canAccess(): bool
@@ -103,6 +103,7 @@ class TransitResource extends Resource
                     ->dateTime()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('transit_type')
+                    ->label('Access Type')
                     ->badge()
                     ->color(fn (string $state): string => match ($state) {
                         'CHECKIN' => 'success',
@@ -117,7 +118,7 @@ class TransitResource extends Resource
                 //
                 Tables\Filters\SelectFilter::make('transit_type')
                     ->options(Transit::TRANSIT_TYPES)
-                    ->label('Transit Type'),
+                    ->label('Access Type'),
                 Tables\Filters\Filter::make('date_of_transit')
                     ->form([
                         Forms\Components\DatePicker::make('created_from')

--- a/app/Models/Transit.php
+++ b/app/Models/Transit.php
@@ -30,7 +30,7 @@ class Transit extends Model
     const TRANSIT_TYPES = [
         'CHECKIN' => 'Check In',
         'CHECKOUT' => 'Check Out',
-        'CHECKINOUT' => 'Check In/Out',
+        'CHECKINOUT' => 'Access',
     ];
 
     // Relationships


### PR DESCRIPTION
## Summary
- rename the tenant transit resource labels and filters to use the new Access terminology
- present the meal resource as Meals across labels and user messaging
- align the activity record overview with the updated Access and Meal names for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f37e857a588331a599390f15ee0c2e