### PR TITLE
Use top navigation and reorganize tenant menu

### DIFF
--- a/app/Filament/Resources/Tenant/ActivityRecordResource.php
+++ b/app/Filament/Resources/Tenant/ActivityRecordResource.php
@@ -26,15 +26,15 @@ class ActivityRecordResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
 
-    protected static ?string $navigationGroup = 'Guest Requests';
+    protected static ?string $navigationGroup = 'Scans';
 
-    protected static ?string $navigationLabel = 'All Records';
+    protected static ?string $navigationLabel = 'Scan History';
 
     protected static ?string $modelLabel = 'Activity Record';
 
     protected static ?string $pluralModelLabel = 'Activity Records';
 
-    protected static ?int $navigationSort = 1; // Show at top of Guest Requests group
+    protected static ?int $navigationSort = 1; // Show at top of Scans group
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Resources/Tenant/CheckInResource.php
+++ b/app/Filament/Resources/Tenant/CheckInResource.php
@@ -28,7 +28,9 @@ class CheckInResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-key';
 
-    protected static ?string $navigationGroup = 'User Management';
+    protected static ?string $navigationGroup = 'Property';
+
+    protected static ?string $navigationLabel = 'Manual Check-Ins';
 
     protected static ?string $modelLabel = 'Check-In';
 

--- a/app/Filament/Resources/Tenant/CustomRequestResource.php
+++ b/app/Filament/Resources/Tenant/CustomRequestResource.php
@@ -26,7 +26,7 @@ class CustomRequestResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
 
-    protected static ?string $navigationGroup = 'Guest Requests';
+    protected static ?string $navigationGroup = 'Property';
 
     protected static ?string $navigationLabel = 'Guest Requests';
 

--- a/app/Filament/Resources/Tenant/GuestResource.php
+++ b/app/Filament/Resources/Tenant/GuestResource.php
@@ -26,7 +26,7 @@ class GuestResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-users';
 
-    protected static ?string $navigationGroup = 'Property Management';
+    protected static ?string $navigationGroup = 'Property';
 
     protected static ?string $pluralModelLabel = 'Profiles';
 

--- a/app/Filament/Resources/Tenant/MealRecordResource.php
+++ b/app/Filament/Resources/Tenant/MealRecordResource.php
@@ -26,7 +26,9 @@ class MealRecordResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
-    protected static ?string $navigationGroup = 'Guest Requests';
+    protected static ?string $navigationGroup = 'Scans';
+
+    protected static ?string $navigationLabel = 'Meal Scans';
 
     protected static ?string $modelLabel = 'Meal Record';
 

--- a/app/Filament/Resources/Tenant/PermissionResource.php
+++ b/app/Filament/Resources/Tenant/PermissionResource.php
@@ -25,7 +25,7 @@ class PermissionResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-key';
 
-    protected static ?string $navigationGroup = 'User Management';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 3;
 

--- a/app/Filament/Resources/Tenant/RoleResource.php
+++ b/app/Filament/Resources/Tenant/RoleResource.php
@@ -26,7 +26,7 @@ class RoleResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
-    protected static ?string $navigationGroup = 'User Management';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 2;
 

--- a/app/Filament/Resources/Tenant/RoomResource.php
+++ b/app/Filament/Resources/Tenant/RoomResource.php
@@ -29,7 +29,7 @@ class RoomResource extends Resource
 
     protected static ?string $navigationLabel = 'Rooms';
 
-    protected static ?string $navigationGroup = 'Property Management';
+    protected static ?string $navigationGroup = 'Property';
 
     protected static ?int $navigationSort = 1;
 

--- a/app/Filament/Resources/Tenant/ScannerResource.php
+++ b/app/Filament/Resources/Tenant/ScannerResource.php
@@ -29,7 +29,7 @@ class ScannerResource extends Resource
 
     protected static ?string $navigationLabel = 'Scanners';
 
-    protected static ?string $navigationGroup = 'Settings';
+    protected static ?string $navigationGroup = 'Scans';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Resources/Tenant/TransitResource.php
+++ b/app/Filament/Resources/Tenant/TransitResource.php
@@ -28,7 +28,9 @@ class TransitResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-key';
 
-    protected static ?string $navigationGroup = 'Guest Requests';
+    protected static ?string $navigationGroup = 'Scans';
+
+    protected static ?string $navigationLabel = 'Transit Log';
 
     protected static ?string $modelLabel = 'In/Out Record';
 

--- a/app/Filament/Resources/Tenant/UserTenantResource.php
+++ b/app/Filament/Resources/Tenant/UserTenantResource.php
@@ -29,7 +29,7 @@ class UserTenantResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-users';
 
-    protected static ?string $navigationGroup = 'User Management';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 1;
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Http\Middleware\FilamentPermissionMiddleware;
+use Filament\Navigation\NavigationGroup;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -27,6 +28,12 @@ class AdminPanelProvider extends PanelProvider
             ->default()
             ->id('admin')
             ->path('admin')
+            ->topNavigation()
+            ->navigationGroups([
+                NavigationGroup::make()->label('Property'),
+                NavigationGroup::make()->label('Scans'),
+                NavigationGroup::make()->label('Settings'),
+            ])
             ->login()
             ->colors([
                 'primary' => Color::Amber,


### PR DESCRIPTION
## Summary
- enable Filament's top navigation layout for the tenant panel and register Property, Scans, and Settings groups
- move tenant resources into the new navigation groups and refresh labels for scan-related sections

## Testing
- php artisan test *(fails: No application encryption key has been specified.)*

------
https://chatgpt.com/codex/tasks/task_e_68f37e66f7bc8331b6d6a1305566fd85