### PR TITLE
Replace tenant dashboard with operational widgets

### DIFF
--- a/app/Filament/Pages/Tenant/Dashboard.php
+++ b/app/Filament/Pages/Tenant/Dashboard.php
@@ -3,13 +3,11 @@
 namespace App\Filament\Pages\Tenant;
 
 use App\Filament\Widgets\AbsenceTrackerWidget;
-use App\Filament\Widgets\AgeDistributionChart;
-use App\Filament\Widgets\BirthdaysWidget;
-use App\Filament\Widgets\GenderDistributionChart;
-use App\Filament\Widgets\OccupancyTrendChart;
-use App\Filament\Widgets\ResidentStatsOverview;
-use App\Filament\Widgets\ResidentTypeChart;
-use App\Filament\Widgets\TopNationalitiesChart;
+use App\Filament\Widgets\EmergencyRollCallWidget;
+use App\Filament\Widgets\LastShiftReportWidget;
+use App\Filament\Widgets\MissedConsumablesWidget;
+use App\Filament\Widgets\MissedMealsWidget;
+use App\Filament\Widgets\PersonsOnSiteWidget;
 use Filament\Pages\Dashboard as BaseDashboard;
 
 class Dashboard extends BaseDashboard
@@ -23,32 +21,15 @@ class Dashboard extends BaseDashboard
         return 'Resident Statistics Dashboard';
     }
 
-    protected function getHeaderWidgets(): array
-    {
-        return [
-            ResidentStatsOverview::class,
-        ];
-    }
-
-    protected function getFooterWidgets(): array
-    {
-        return [];
-    }
-
-    /**
-     * Register all the custom widgets for the dashboard
-     */
     public function getWidgets(): array
     {
         return [
-            ResidentStatsOverview::class,
-            ResidentTypeChart::class,
-            AgeDistributionChart::class,
-            GenderDistributionChart::class,
-            TopNationalitiesChart::class,
-            OccupancyTrendChart::class,
-            BirthdaysWidget::class,
+            PersonsOnSiteWidget::class,
+            LastShiftReportWidget::class,
+            EmergencyRollCallWidget::class,
             AbsenceTrackerWidget::class,
+            MissedMealsWidget::class,
+            MissedConsumablesWidget::class,
         ];
     }
 }

--- a/app/Filament/Widgets/AbsenceTrackerWidget.php
+++ b/app/Filament/Widgets/AbsenceTrackerWidget.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\AbsenceRecord;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Carbon;
+
+class AbsenceTrackerWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Absences Longer Than 24 Hours';
+
+    protected static ?int $sort = 3;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                AbsenceRecord::longerThan(24)
+                    ->with(['guest', 'guest.assignedRoom', 'checkIn.room'])
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('guest_name')
+                    ->label('Resident')
+                    ->formatStateUsing(fn (AbsenceRecord $record): string => $record->guest?->first_name.' '.$record->guest?->last_name)
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('room')
+                    ->label('Room')
+                    ->getStateUsing(function (AbsenceRecord $record): string {
+                        return $record->guest?->assignedRoom?->room_no
+                            ?? $record->checkIn?->room?->room_no
+                            ?? 'Unassigned';
+                    })
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('start_date')
+                    ->label('Started')
+                    ->dateTime('M d, Y H:i')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('duration')
+                    ->label('Duration')
+                    ->getStateUsing(function (AbsenceRecord $record): string {
+                        $endDate = $record->end_date ?? Carbon::now();
+                        $hours = $record->start_date?->diffInHours($endDate) ?? 0;
+
+                        if ($hours >= 24) {
+                            $days = intdiv($hours, 24);
+                            $remainingHours = $hours % 24;
+
+                            return $remainingHours > 0
+                                ? sprintf('%d d %d h', $days, $remainingHours)
+                                : sprintf('%d d', $days);
+                        }
+
+                        return $hours.' h';
+                    })
+                    ->badge()
+                    ->color(fn (AbsenceRecord $record): string => $record->is_authorized ? 'info' : 'danger'),
+                Tables\Columns\IconColumn::make('is_authorized')
+                    ->label('Authorized')
+                    ->boolean()
+                    ->trueColor('success')
+                    ->falseColor('danger'),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('view_guest')
+                    ->label('View Resident')
+                    ->url(fn (AbsenceRecord $record): string => route('filament.admin.resources.tenant.guests.view', ['record' => $record->guest]))
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->visible(fn (AbsenceRecord $record): bool => filled($record->guest)),
+            ])
+            ->emptyStateHeading('No prolonged absences found')
+            ->defaultSort('start_date', 'desc')
+            ->paginated([10, 25]);
+    }
+}

--- a/app/Filament/Widgets/EmergencyRollCallWidget.php
+++ b/app/Filament/Widgets/EmergencyRollCallWidget.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Guest;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+class EmergencyRollCallWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Emergency Roll Call';
+
+    protected static ?int $sort = 2;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Guest::query()
+                    ->with([
+                        'assignedRoom',
+                        'checkIns' => fn ($query) => $query->latest('date_of_arrival')->limit(1)->with('room'),
+                        'absenceRecords' => fn ($query) => $query
+                            ->where('status', 'active')
+                            ->orderByDesc('start_date'),
+                    ])
+                    ->where('type', 'RESIDENT')
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('full_name')
+                    ->label('Resident')
+                    ->formatStateUsing(fn (Guest $record) => $record->first_name.' '.$record->last_name)
+                    ->searchable(['first_name', 'last_name'])
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('room')
+                    ->label('Room')
+                    ->getStateUsing(function (Guest $record): string {
+                        if ($record->assignedRoom) {
+                            return (string) $record->assignedRoom->room_no;
+                        }
+
+                        $latestCheckIn = $record->checkIns->first();
+
+                        return $latestCheckIn && $latestCheckIn->room ? (string) $latestCheckIn->room->room_no : 'Unassigned';
+                    })
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('last_seen')
+                    ->label('Last Seen')
+                    ->getStateUsing(function (Guest $record): ?string {
+                        $latestCheckIn = $record->checkIns->first();
+
+                        if (! $latestCheckIn) {
+                            return null;
+                        }
+
+                        $timestamp = $latestCheckIn->date_of_departure ?? $latestCheckIn->date_of_arrival;
+
+                        return $timestamp ? Carbon::parse($timestamp)->diffForHumans() : null;
+                    })
+                    ->placeholder('No activity recorded')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('roll_call_status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(function (Guest $record): string {
+                        [$status] = $this->resolveStatus($record);
+
+                        return match ($status) {
+                            'On Site' => 'success',
+                            'Authorized Absence' => 'info',
+                            'Requires Follow-up' => 'danger',
+                            default => 'warning',
+                        };
+                    })
+                    ->formatStateUsing(function (Guest $record): string {
+                        [$status, $note] = $this->resolveStatus($record);
+
+                        return $note ? $status.' · '.$note : $status;
+                    }),
+                Tables\Columns\IconColumn::make('attention')
+                    ->label('Action Needed')
+                    ->getStateUsing(function (Guest $record): bool {
+                        [$status] = $this->resolveStatus($record);
+
+                        return $status === 'Requires Follow-up';
+                    })
+                    ->boolean()
+                    ->trueColor('danger')
+                    ->falseColor('gray')
+                    ->tooltip('Investigate immediately'),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('attention')
+                    ->label('Attention')
+                    ->options([
+                        'requires' => 'Requires Follow-up',
+                        'authorized' => 'Authorized Absence',
+                        'onsite' => 'On Site',
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when($data['value'] ?? null, function (Builder $query, string $value) {
+                            return $query->whereIn('id', $this->idsMatchingStatus($value));
+                        });
+                    }),
+            ])
+            ->defaultSort('first_name')
+            ->paginated([10, 25, 50]);
+    }
+
+    /**
+     * Determine a roll call status for the record.
+     *
+     * @return array{string, string|null}
+     */
+    protected function resolveStatus(Guest $guest): array
+    {
+        $latestCheckIn = $guest->checkIns->first();
+        $activeAbsence = $guest->absenceRecords->first();
+
+        if ($latestCheckIn && ($latestCheckIn->date_of_departure === null || Carbon::parse($latestCheckIn->date_of_departure)->isFuture())) {
+            return ['On Site', null];
+        }
+
+        if ($activeAbsence) {
+            if ($activeAbsence->is_authorized) {
+                return ['Authorized Absence', $activeAbsence->start_date?->diffForHumans()];
+            }
+
+            return ['Requires Follow-up', $activeAbsence->start_date?->diffForHumans()];
+        }
+
+        return ['Checked Out', $latestCheckIn?->date_of_departure?->diffForHumans()];
+    }
+
+    /**
+     * Resolve guest ids that match a filter value.
+     */
+    protected function idsMatchingStatus(string $statusKey): array
+    {
+        $guests = Guest::query()
+            ->with([
+                'checkIns' => fn ($query) => $query->latest('date_of_arrival')->limit(1),
+                'absenceRecords' => fn ($query) => $query->where('status', 'active')->orderByDesc('start_date'),
+            ])
+            ->where('type', 'RESIDENT')
+            ->get();
+
+        return $guests->filter(function (Guest $guest) use ($statusKey) {
+            [$status] = $this->resolveStatus($guest);
+
+            return match ($statusKey) {
+                'requires' => $status === 'Requires Follow-up',
+                'authorized' => $status === 'Authorized Absence',
+                'onsite' => $status === 'On Site',
+                default => false,
+            };
+        })->pluck('id')->all();
+    }
+}

--- a/app/Filament/Widgets/LastShiftReportWidget.php
+++ b/app/Filament/Widgets/LastShiftReportWidget.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\DailyReport;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Form;
+use Filament\Widgets\Widget;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+class LastShiftReportWidget extends Widget
+{
+    use InteractsWithForms;
+
+    protected static string $view = 'filament.widgets.last-shift-report-widget';
+
+    protected static ?string $heading = 'Last Shift Report';
+
+    public ?array $data = [];
+
+    public ?string $selectedDate = null;
+
+    protected int|string|array $columnSpan = [
+        'default' => 1,
+        'md' => 2,
+        'xl' => 2,
+    ];
+
+    public function mount(): void
+    {
+        $this->selectedDate = Carbon::yesterday()->toDateString();
+        $this->form->fill($this->getInitialFormState());
+    }
+
+    protected function getForms(): array
+    {
+        return [
+            'form' => $this->makeForm()
+                ->schema($this->getFormSchema())
+                ->statePath('data'),
+        ];
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema($this->getFormSchema())
+            ->statePath('data');
+    }
+
+    protected function getFormSchema(): array
+    {
+        return [
+            DatePicker::make('selected_date')
+                ->label('Shift Date')
+                ->default(fn () => Carbon::parse($this->selectedDate))
+                ->maxDate(Carbon::today())
+                ->reactive()
+                ->afterStateHydrated(function (DatePicker $component, $state): void {
+                    if (! $state) {
+                        $component->state($this->selectedDate);
+                    }
+                })
+                ->afterStateUpdated(function ($state): void {
+                    $this->selectedDate = $state;
+                    $this->reloadReport();
+                }),
+            Textarea::make('report')
+                ->label('Report Notes')
+                ->rows(8)
+                ->placeholder('No report has been logged for this shift.')
+                ->reactive()
+                ->disabled(fn (): bool => ! $this->canEditSelectedDate())
+                ->afterStateHydrated(function (Textarea $component, $state): void {
+                    if ($state === null && $this->selectedDate) {
+                        $component->state($this->resolveReport($this->selectedDate)?->content ?? '');
+                    }
+                })
+                ->afterStateUpdated(function ($state): void {
+                    $this->persistReport($state);
+                }),
+        ];
+    }
+
+    protected function getInitialFormState(): array
+    {
+        $report = $this->resolveReport($this->selectedDate, createIfMissing: true);
+
+        return [
+            'selected_date' => $this->selectedDate,
+            'report' => $report?->content,
+        ];
+    }
+
+    protected function reloadReport(): void
+    {
+        $report = $this->resolveReport($this->selectedDate);
+
+        $this->form->fill([
+            'selected_date' => $this->selectedDate,
+            'report' => $report?->content,
+        ]);
+    }
+
+    protected function persistReport(?string $content): void
+    {
+        if (! $this->selectedDate || ! $this->canEditSelectedDate()) {
+            return;
+        }
+
+        DailyReport::updateOrCreate(
+            ['date' => $this->selectedDate],
+            ['content' => $content ?? '']
+        );
+    }
+
+    protected function resolveReport(?string $date, bool $createIfMissing = false): ?DailyReport
+    {
+        if (! $date) {
+            return null;
+        }
+
+        $report = DailyReport::whereDate('date', $date)->first();
+
+        if ($report) {
+            return $report;
+        }
+
+        if (! $createIfMissing) {
+            return null;
+        }
+
+        return DailyReport::create([
+            'date' => $date,
+            'content' => '',
+        ]);
+    }
+
+    protected function getViewData(): array
+    {
+        $reportContent = Arr::get($this->data, 'report');
+
+        if ($reportContent === null && $this->selectedDate) {
+            $reportContent = $this->resolveReport($this->selectedDate)?->content;
+        }
+
+        return [
+            'selectedDate' => $this->selectedDate,
+            'reportIsMissing' => blank($reportContent),
+            'isEditable' => $this->canEditSelectedDate(),
+        ];
+    }
+
+    protected function canEditSelectedDate(): bool
+    {
+        if (! $this->selectedDate) {
+            return false;
+        }
+
+        $allowed = [
+            Carbon::today()->toDateString(),
+            Carbon::yesterday()->toDateString(),
+        ];
+
+        return in_array($this->selectedDate, $allowed, true);
+    }
+}

--- a/app/Filament/Widgets/MissedConsumablesWidget.php
+++ b/app/Filament/Widgets/MissedConsumablesWidget.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\CustomRequest;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Carbon;
+
+class MissedConsumablesWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Missed Consumables';
+
+    protected static ?int $sort = 5;
+
+    protected int|string|array $columnSpan = [
+        'default' => 1,
+        'md' => 1,
+        'xl' => 1,
+    ];
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                CustomRequest::query()
+                    ->with(['guest', 'room', 'consumable'])
+                    ->where('request_type', 'CONSUMABLE')
+                    ->where('status', 'PENDING')
+                    ->orderByDesc('created_at')
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('guest_name')
+                    ->label('Requester')
+                    ->formatStateUsing(fn (CustomRequest $record): string => $record->guest?->first_name.' '.$record->guest?->last_name)
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('consumable.name')
+                    ->label('Consumable')
+                    ->placeholder('N/A')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Requested')
+                    ->since()
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('follow_up')
+                    ->label('Follow-up')
+                    ->getStateUsing(fn (CustomRequest $record): bool => $this->isOverdue($record, 6))
+                    ->boolean()
+                    ->trueColor('danger')
+                    ->falseColor('success')
+                    ->tooltip(fn (CustomRequest $record): string => $this->isOverdue($record, 6) ? 'Older than 6 hours' : 'Within response window'),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('open_request')
+                    ->label('Open Request')
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn (CustomRequest $record): string => route('filament.admin.resources.tenant.custom-requests.view', ['record' => $record]))
+                    ->visible(fn (CustomRequest $record): bool => filled($record->id)),
+            ])
+            ->emptyStateHeading('No outstanding consumable requests')
+            ->defaultPaginationPageOption(5)
+            ->paginated([5, 10]);
+    }
+
+    protected function isOverdue(CustomRequest $request, int $hours = 12): bool
+    {
+        $threshold = Carbon::now()->subHours($hours);
+
+        return $request->created_at?->lessThanOrEqualTo($threshold) ?? false;
+    }
+}

--- a/app/Filament/Widgets/MissedMealsWidget.php
+++ b/app/Filament/Widgets/MissedMealsWidget.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\CustomRequest;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Carbon;
+
+class MissedMealsWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Missed Meals';
+
+    protected static ?int $sort = 4;
+
+    protected int|string|array $columnSpan = [
+        'default' => 1,
+        'md' => 1,
+        'xl' => 1,
+    ];
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                CustomRequest::query()
+                    ->with(['guest', 'room'])
+                    ->where('request_type', 'LATE_DINNER')
+                    ->where('status', 'PENDING')
+                    ->latest()
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('guest_name')
+                    ->label('Resident')
+                    ->formatStateUsing(fn (CustomRequest $record): string => $record->guest?->first_name.' '.$record->guest?->last_name)
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('room.room_no')
+                    ->label('Room')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Requested')
+                    ->since()
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('overdue')
+                    ->label('Overdue')
+                    ->getStateUsing(fn (CustomRequest $record): bool => $this->isOverdue($record))
+                    ->boolean()
+                    ->trueColor('danger')
+                    ->falseColor('success')
+                    ->tooltip(fn (CustomRequest $record): string => $this->isOverdue($record) ? 'Older than 12 hours' : 'Within response window'),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('open_request')
+                    ->label('Open Request')
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn (CustomRequest $record): string => route('filament.admin.resources.tenant.custom-requests.view', ['record' => $record]))
+                    ->visible(fn (CustomRequest $record): bool => filled($record->id)),
+            ])
+            ->emptyStateHeading('No missed meal alerts')
+            ->defaultPaginationPageOption(5)
+            ->paginated([5, 10]);
+    }
+
+    protected function isOverdue(CustomRequest $request): bool
+    {
+        $threshold = Carbon::now()->subHours(12);
+
+        return $request->created_at?->lessThanOrEqualTo($threshold) ?? false;
+    }
+}

--- a/app/Filament/Widgets/PersonsOnSiteWidget.php
+++ b/app/Filament/Widgets/PersonsOnSiteWidget.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\AbsenceRecord;
+use App\Models\CheckIn;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
+
+class PersonsOnSiteWidget extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected int|string|array $columnSpan = [
+        'default' => 1,
+        'md' => 2,
+        'xl' => 2,
+    ];
+
+    protected function getStats(): array
+    {
+        $now = Carbon::now();
+
+        $activeCheckInsQuery = CheckIn::query()
+            ->where('date_of_arrival', '<=', $now)
+            ->where(function ($query) use ($now) {
+                $query->whereNull('date_of_departure')
+                    ->orWhere('date_of_departure', '>', $now);
+            });
+
+        $totalOnSite = (clone $activeCheckInsQuery)->count();
+        $residentsOnSite = (clone $activeCheckInsQuery)
+            ->whereHas('guest', fn ($query) => $query->where('type', 'RESIDENT'))
+            ->count();
+        $staffOnSite = (clone $activeCheckInsQuery)
+            ->whereHas('guest', fn ($query) => $query->where('type', 'STAFF'))
+            ->count();
+        $visitorsOnSite = (clone $activeCheckInsQuery)
+            ->whereHas('guest', fn ($query) => $query->where('type', 'VISITORS'))
+            ->count();
+
+        $authorizedAbsences = AbsenceRecord::active()
+            ->where('is_authorized', true)
+            ->count();
+        $unauthorizedAbsences = AbsenceRecord::active()
+            ->where('is_authorized', false)
+            ->count();
+
+        return [
+            Stat::make('People On Site', number_format($totalOnSite))
+                ->description('Active check-ins right now')
+                ->icon('heroicon-o-users'),
+            Stat::make('Residents On Site', number_format($residentsOnSite))
+                ->description('Residents currently checked in')
+                ->icon('heroicon-o-home'),
+            Stat::make('Staff On Site', number_format($staffOnSite))
+                ->description('Staff members inside the centre')
+                ->icon('heroicon-o-briefcase'),
+            Stat::make('Visitors On Site', number_format($visitorsOnSite))
+                ->description('Registered visitors present today')
+                ->icon('heroicon-o-user-group'),
+            Stat::make('Unauthorized Absences', number_format($unauthorizedAbsences))
+                ->description($authorizedAbsences.' authorised')
+                ->descriptionIcon('heroicon-m-check-circle')
+                ->color($unauthorizedAbsences > 0 ? 'danger' : 'success')
+                ->icon('heroicon-o-exclamation-circle'),
+        ];
+    }
+}

--- a/resources/views/filament/pages/dashboard.blade.php
+++ b/resources/views/filament/pages/dashboard.blade.php
@@ -1,33 +1,19 @@
 <x-filament-panels::page>
-    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
-        @livewire(\App\Filament\Widgets\ResidentStatsOverview::class)
-    </div>
-
-    <div class="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        <div class="col-span-1">
-            @livewire(\App\Filament\Widgets\ResidentTypeChart::class)
-        </div>
-        <div class="col-span-1">
-            @livewire(\App\Filament\Widgets\AgeDistributionChart::class)
-        </div>
-        <div class="col-span-1">
-            @livewire(\App\Filament\Widgets\GenderDistributionChart::class)
-        </div>
-    </div>
-
-    <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div class="col-span-1">
-            @livewire(\App\Filament\Widgets\TopNationalitiesChart::class)
-        </div>
-        <div class="col-span-1">
-            @livewire(\App\Filament\Widgets\OccupancyTrendChart::class)
-        </div>
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+        @livewire(\App\Filament\Widgets\PersonsOnSiteWidget::class)
+        @livewire(\App\Filament\Widgets\LastShiftReportWidget::class)
     </div>
 
     <div class="mt-6 grid grid-cols-1 gap-6">
-        @livewire(\App\Filament\Widgets\BirthdaysWidget::class)
+        @livewire(\App\Filament\Widgets\EmergencyRollCallWidget::class)
     </div>
+
     <div class="mt-6 grid grid-cols-1 gap-6">
         @livewire(\App\Filament\Widgets\AbsenceTrackerWidget::class)
+    </div>
+
+    <div class="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
+        @livewire(\App\Filament\Widgets\MissedMealsWidget::class)
+        @livewire(\App\Filament\Widgets\MissedConsumablesWidget::class)
     </div>
 </x-filament-panels::page>

--- a/resources/views/filament/widgets/last-shift-report-widget.blade.php
+++ b/resources/views/filament/widgets/last-shift-report-widget.blade.php
@@ -1,0 +1,31 @@
+<x-filament::widget>
+    <x-filament::section>
+        <x-slot name="heading">
+            Last Shift Report
+        </x-slot>
+
+        <x-slot name="description">
+            Review and update the narrative for recent shifts.
+        </x-slot>
+
+        <x-slot name="headerEnd">
+            @if ($reportIsMissing)
+                <x-filament::badge color="danger">
+                    Awaiting update
+                </x-filament::badge>
+            @else
+                <x-filament::badge color="success">
+                    Report available
+                </x-filament::badge>
+            @endif
+        </x-slot>
+
+        {{ $this->form }}
+
+        @unless ($isEditable)
+            <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
+                Only today's and yesterday's reports can be edited.
+            </p>
+        @endunless
+    </x-filament::section>
+</x-filament::widget>


### PR DESCRIPTION
## Summary
- swap the tenant dashboard widget list to show operational widgets for shift reports, head counts, emergency roll call, absences, and outstanding requests
- add new Livewire/Filament widgets to surface last shift reports, people on site metrics, emergency roll call details, long absences, and missed meal/consumable requests
- rebuild the dashboard blade layout and add a dedicated view for the shift report widget

## Testing
- `php artisan test` *(fails: vendor autoloader missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f37e8f3a0c8331a72a3afb09cfc220