### PR TITLE
Add scan item management resource and notification wiring

### DIFF
--- a/app/Filament/Resources/Tenant/ScanItemResource.php
+++ b/app/Filament/Resources/Tenant/ScanItemResource.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Filament\Resources\Tenant;
+
+use App\Filament\Resources\Tenant\ScanItemResource\Pages;
+use App\Filament\Traits\HasPermissionBasedAccess;
+use App\Models\ScanItem;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Arr;
+
+class ScanItemResource extends Resource
+{
+    use HasPermissionBasedAccess;
+
+    protected static ?string $model = ScanItem::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-group';
+
+    protected static ?string $navigationLabel = 'Scan Items';
+
+    protected static ?string $navigationGroup = 'Scans';
+
+    protected static ?string $modelLabel = 'Scan Item';
+
+    protected static ?string $pluralModelLabel = 'Scan Items';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make('Scan Item Details')
+                    ->schema([
+                        TextInput::make('name')
+                            ->label('Item Name')
+                            ->required()
+                            ->maxLength(255),
+                        Select::make('type')
+                            ->label('Item Type')
+                            ->options(ScanItem::types())
+                            ->required()
+                            ->live(),
+                        Textarea::make('description')
+                            ->rows(3)
+                            ->columnSpanFull(),
+                        Toggle::make('is_active')
+                            ->label('Active')
+                            ->default(true)
+                            ->helperText('Inactive items are hidden from scanners and dashboard alerts.'),
+                        Toggle::make('notify_if_missed')
+                            ->label('Notify if Missed')
+                            ->visible(fn (callable $get) => $get('type') === ScanItem::TYPE_CONSUMABLE)
+                            ->dehydrateStateUsing(fn ($state, callable $get) => $get('type') === ScanItem::TYPE_CONSUMABLE ? (bool) $state : false)
+                            ->helperText('Enable alerts when a consumable item is not scanned during its active window.'),
+                    ])
+                    ->columns(2),
+                Section::make('Active Period')
+                    ->schema([
+                        Select::make('active_period_type')
+                            ->label('Schedule Type')
+                            ->options(ScanItem::periodTypes())
+                            ->default(ScanItem::PERIOD_ALWAYS)
+                            ->required()
+                            ->live(),
+                        TimePicker::make('active_start_time')
+                            ->label('Start Time')
+                            ->seconds(false)
+                            ->visible(fn (callable $get) => in_array($get('active_period_type'), [ScanItem::PERIOD_WEEKDAYS], true))
+                            ->dehydrateStateUsing(fn ($state, callable $get) => $get('active_period_type') === ScanItem::PERIOD_WEEKDAYS ? $state : null),
+                        TimePicker::make('active_end_time')
+                            ->label('End Time')
+                            ->seconds(false)
+                            ->visible(fn (callable $get) => in_array($get('active_period_type'), [ScanItem::PERIOD_WEEKDAYS], true))
+                            ->dehydrateStateUsing(fn ($state, callable $get) => $get('active_period_type') === ScanItem::PERIOD_WEEKDAYS ? $state : null),
+                        CheckboxList::make('active_days')
+                            ->label('Active Days')
+                            ->options([
+                                'MONDAY' => 'Monday',
+                                'TUESDAY' => 'Tuesday',
+                                'WEDNESDAY' => 'Wednesday',
+                                'THURSDAY' => 'Thursday',
+                                'FRIDAY' => 'Friday',
+                                'SATURDAY' => 'Saturday',
+                                'SUNDAY' => 'Sunday',
+                            ])
+                            ->columns(2)
+                            ->visible(fn (callable $get) => $get('active_period_type') === ScanItem::PERIOD_WEEKDAYS)
+                            ->default(fn () => ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'])
+                            ->dehydrateStateUsing(fn ($state, callable $get) => $get('active_period_type') === ScanItem::PERIOD_WEEKDAYS
+                                ? array_values(array_filter((array) $state))
+                                : null),
+                        Repeater::make('custom_windows')
+                            ->label('Custom Windows')
+                            ->schema([
+                                CheckboxList::make('days')
+                                    ->label('Days')
+                                    ->options([
+                                        'MONDAY' => 'Monday',
+                                        'TUESDAY' => 'Tuesday',
+                                        'WEDNESDAY' => 'Wednesday',
+                                        'THURSDAY' => 'Thursday',
+                                        'FRIDAY' => 'Friday',
+                                        'SATURDAY' => 'Saturday',
+                                        'SUNDAY' => 'Sunday',
+                                    ])
+                                    ->columns(2),
+                                TimePicker::make('start')
+                                    ->label('Start Time')
+                                    ->required()
+                                    ->seconds(false),
+                                TimePicker::make('end')
+                                    ->label('End Time')
+                                    ->required()
+                                    ->seconds(false),
+                            ])
+                            ->default([])
+                            ->collapsed()
+                            ->visible(fn (callable $get) => $get('active_period_type') === ScanItem::PERIOD_CUSTOM)
+                            ->dehydrateStateUsing(fn ($state, callable $get) => $get('active_period_type') === ScanItem::PERIOD_CUSTOM
+                                ? collect($state ?? [])->map(function (array $window) {
+                                    $days = array_values(array_filter($window['days'] ?? []));
+
+                                    return [
+                                        'days' => $days,
+                                        'start' => $window['start'] ?? null,
+                                        'end' => $window['end'] ?? null,
+                                    ];
+                                })->filter(function (array $window) {
+                                    return ($window['start'] ?? null) && ($window['end'] ?? null);
+                                })->values()->all()
+                                : null)
+                            ->grid(1),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('type')
+                    ->label('Type')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        ScanItem::TYPE_ACCESS => 'success',
+                        ScanItem::TYPE_MEAL => 'info',
+                        ScanItem::TYPE_CONSUMABLE => 'warning',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => Arr::get(ScanItem::types(), $state, ucfirst($state)))
+                    ->sortable(),
+                TextColumn::make('active_period_summary')
+                    ->label('Active Period')
+                    ->wrap()
+                    ->sortable(),
+                IconColumn::make('notify_if_missed')
+                    ->label('Notify')
+                    ->boolean(),
+                IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean(),
+                TextColumn::make('updated_at')
+                    ->since()
+                    ->label('Updated'),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->label('Item Type')
+                    ->options(ScanItem::types()),
+                SelectFilter::make('active_period_type')
+                    ->label('Schedule Type')
+                    ->options(ScanItem::periodTypes()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListScanItems::route('/'),
+            'create' => Pages\CreateScanItem::route('/create'),
+            'edit' => Pages\EditScanItem::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Tenant/ScanItemResource/Pages/CreateScanItem.php
+++ b/app/Filament/Resources/Tenant/ScanItemResource/Pages/CreateScanItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Tenant\ScanItemResource\Pages;
+
+use App\Filament\Resources\Tenant\ScanItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateScanItem extends CreateRecord
+{
+    protected static string $resource = ScanItemResource::class;
+}

--- a/app/Filament/Resources/Tenant/ScanItemResource/Pages/EditScanItem.php
+++ b/app/Filament/Resources/Tenant/ScanItemResource/Pages/EditScanItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Tenant\ScanItemResource\Pages;
+
+use App\Filament\Resources\Tenant\ScanItemResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditScanItem extends EditRecord
+{
+    protected static string $resource = ScanItemResource::class;
+}

--- a/app/Filament/Resources/Tenant/ScanItemResource/Pages/ListScanItems.php
+++ b/app/Filament/Resources/Tenant/ScanItemResource/Pages/ListScanItems.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Tenant\ScanItemResource\Pages;
+
+use App\Filament\Resources\Tenant\ScanItemResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListScanItems extends ListRecords
+{
+    protected static string $resource = ScanItemResource::class;
+}

--- a/app/Models/ScanItem.php
+++ b/app/Models/ScanItem.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Spatie\Multitenancy\Models\Concerns\UsesTenantConnection;
+
+class ScanItem extends Model
+{
+    use HasFactory;
+    use UsesTenantConnection;
+
+    public const TYPE_ACCESS = 'access';
+    public const TYPE_MEAL = 'meal';
+    public const TYPE_CONSUMABLE = 'consumable';
+
+    public const PERIOD_ALWAYS = 'always';
+    public const PERIOD_WEEKDAYS = 'weekdays';
+    public const PERIOD_CUSTOM = 'custom';
+
+    protected $fillable = [
+        'name',
+        'type',
+        'description',
+        'is_active',
+        'active_period_type',
+        'active_days',
+        'active_start_time',
+        'active_end_time',
+        'custom_windows',
+        'notify_if_missed',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'notify_if_missed' => 'boolean',
+        'active_days' => 'array',
+        'custom_windows' => 'array',
+    ];
+
+    protected $appends = [
+        'active_period_summary',
+    ];
+
+    public static function types(): array
+    {
+        return [
+            self::TYPE_ACCESS => 'Access',
+            self::TYPE_MEAL => 'Meals',
+            self::TYPE_CONSUMABLE => 'Consumables',
+        ];
+    }
+
+    public static function periodTypes(): array
+    {
+        return [
+            self::PERIOD_ALWAYS => '24/7',
+            self::PERIOD_WEEKDAYS => 'Weekdays',
+            self::PERIOD_CUSTOM => 'Custom Windows',
+        ];
+    }
+
+    /**
+     * Accessor for a human-readable summary of the configured active period.
+     */
+    protected function activePeriodSummary(): Attribute
+    {
+        return Attribute::get(function (): string {
+            return match ($this->active_period_type) {
+                self::PERIOD_ALWAYS => '24/7',
+                self::PERIOD_WEEKDAYS => $this->formatWeekdaySummary(),
+                self::PERIOD_CUSTOM => $this->formatCustomSummary(),
+                default => 'Unconfigured',
+            };
+        });
+    }
+
+    protected function formatWeekdaySummary(): string
+    {
+        $start = $this->active_start_time ? Carbon::parse($this->active_start_time)->format('g:i A') : '12:00 AM';
+        $end = $this->active_end_time ? Carbon::parse($this->active_end_time)->format('g:i A') : '11:59 PM';
+
+        return "Weekdays {$start} - {$end}";
+    }
+
+    protected function formatCustomSummary(): string
+    {
+        $windows = collect($this->custom_windows ?? [])->map(function (array $window) {
+            $days = collect($window['days'] ?? [])->map(fn ($day) => ucfirst(strtolower($day)))->implode(', ');
+            $start = isset($window['start']) ? Carbon::parse($window['start'])->format('g:i A') : 'N/A';
+            $end = isset($window['end']) ? Carbon::parse($window['end'])->format('g:i A') : 'N/A';
+
+            return trim($days ? "{$days}: {$start} - {$end}" : "{$start} - {$end}");
+        })->filter()->implode('; ');
+
+        return $windows !== '' ? $windows : 'Custom schedule';
+    }
+
+    public function shouldNotifyForMissedScan(): bool
+    {
+        return $this->type === self::TYPE_CONSUMABLE && $this->notify_if_missed;
+    }
+
+    public function scopeRequiringNotification($query)
+    {
+        return $query->where('type', self::TYPE_CONSUMABLE)
+            ->where('notify_if_missed', true)
+            ->where('is_active', true);
+    }
+
+    public function getActiveWindowsForDate(Carbon $date): Collection
+    {
+        return match ($this->active_period_type) {
+            self::PERIOD_ALWAYS => collect([[
+                'day' => strtoupper($date->format('l')),
+                'start' => '00:00:00',
+                'end' => '23:59:59',
+            ]]),
+            self::PERIOD_WEEKDAYS => $this->resolveWeekdayWindow($date),
+            self::PERIOD_CUSTOM => $this->resolveCustomWindows($date),
+            default => collect(),
+        };
+    }
+
+    protected function resolveWeekdayWindow(Carbon $date): Collection
+    {
+        $weekdays = $this->active_days ?? ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'];
+        $dayKey = strtoupper($date->format('l'));
+
+        if (! in_array($dayKey, $weekdays, true)) {
+            return collect();
+        }
+
+        return collect([[
+            'day' => $dayKey,
+            'start' => $this->active_start_time ?? '00:00:00',
+            'end' => $this->active_end_time ?? '23:59:59',
+        ]]);
+    }
+
+    protected function resolveCustomWindows(Carbon $date): Collection
+    {
+        $dayKey = strtoupper($date->format('l'));
+
+        return collect($this->custom_windows ?? [])
+            ->filter(function (array $window) use ($dayKey) {
+                $days = collect($window['days'] ?? [])->map(fn ($day) => strtoupper($day));
+
+                return $days->isEmpty() || $days->contains($dayKey);
+            })
+            ->map(function (array $window) use ($dayKey) {
+                return [
+                    'day' => $dayKey,
+                    'start' => $window['start'] ?? '00:00:00',
+                    'end' => $window['end'] ?? '23:59:59',
+                ];
+            });
+    }
+
+    public function toNotificationPayload(?Carbon $date = null): array
+    {
+        $date ??= Carbon::now();
+        $windows = $this->getActiveWindowsForDate($date);
+
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type,
+            'active_period_type' => $this->active_period_type,
+            'active_windows' => $windows->values()->all(),
+            'notify_if_missed' => $this->shouldNotifyForMissedScan(),
+            'is_active' => $this->is_active,
+        ];
+    }
+}

--- a/app/Services/ScanItemNotificationService.php
+++ b/app/Services/ScanItemNotificationService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ScanItem;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class ScanItemNotificationService
+{
+    /**
+     * Retrieve scan items that should trigger missed scan notifications.
+     */
+    public function getActiveNotificationPayloads(?Carbon $date = null): Collection
+    {
+        $date ??= Carbon::now();
+
+        return ScanItem::query()
+            ->requiringNotification()
+            ->get()
+            ->map(fn (ScanItem $item) => $item->toNotificationPayload($date))
+            ->filter(fn (array $payload) => ! empty($payload['active_windows']));
+    }
+}

--- a/database/migrations/tenant/2025_05_13_000001_create_scan_items_table.php
+++ b/database/migrations/tenant/2025_05_13_000001_create_scan_items_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scan_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('type');
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->string('active_period_type')->default('always');
+            $table->json('active_days')->nullable();
+            $table->time('active_start_time')->nullable();
+            $table->time('active_end_time')->nullable();
+            $table->json('custom_windows')->nullable();
+            $table->boolean('notify_if_missed')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scan_items');
+    }
+};

--- a/database/seeders/TenantDatabaseSeeder.php
+++ b/database/seeders/TenantDatabaseSeeder.php
@@ -6,6 +6,7 @@ namespace Database\Seeders;
 use App\Models\Consumable;
 use App\Models\Guest;
 use App\Models\Meal;
+use App\Models\ScanItem;
 use App\Models\Permission;
 use App\Models\ModelHasRole;
 use App\Models\Role;
@@ -190,6 +191,50 @@ class TenantDatabaseSeeder extends Seeder
             ],
         ]);
 
+        ScanItem::insert([
+            [
+                'name' => 'Main Entrance',
+                'type' => ScanItem::TYPE_ACCESS,
+                'description' => 'Primary access scanner for the building',
+                'is_active' => true,
+                'active_period_type' => ScanItem::PERIOD_ALWAYS,
+                'active_days' => null,
+                'notify_if_missed' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'name' => 'Daily Breakfast',
+                'type' => ScanItem::TYPE_MEAL,
+                'description' => 'Standard breakfast service window',
+                'is_active' => true,
+                'active_period_type' => ScanItem::PERIOD_WEEKDAYS,
+                'active_days' => json_encode(['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY']),
+                'active_start_time' => '06:00:00',
+                'active_end_time' => '09:00:00',
+                'notify_if_missed' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'name' => 'Wellness Pack',
+                'type' => ScanItem::TYPE_CONSUMABLE,
+                'description' => 'Daily amenity pack distribution',
+                'is_active' => true,
+                'active_period_type' => ScanItem::PERIOD_CUSTOM,
+                'custom_windows' => json_encode([
+                    [
+                        'days' => ['MONDAY', 'WEDNESDAY', 'FRIDAY'],
+                        'start' => '10:00:00',
+                        'end' => '12:00:00',
+                    ],
+                ]),
+                'notify_if_missed' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
     }
 
     /**
@@ -201,7 +246,7 @@ class TenantDatabaseSeeder extends Seeder
         $resources = [
             'user', 'role', 'permission', 'guest', 'room', 'meal',
             'meal-record', 'consumable', 'check-in', 'guest-request',
-            'daily-report', 'scanner', 'transit',
+            'daily-report', 'scanner', 'transit', 'scan-item',
         ];
 
         // Define standard CRUD operations
@@ -274,6 +319,7 @@ class TenantDatabaseSeeder extends Seeder
             'view guest-request', 'create guest-request', 'update guest-request', 'delete guest-request',
             'view daily-report', 'create daily-report', 'update daily-report',
             'view scanner', 'create scanner', 'update scanner', 'delete scanner',
+            'view scan-item', 'create scan-item', 'update scan-item', 'delete scan-item',
             'view transit', 'create transit', 'update transit', 'delete transit',
             'access admin panel', 'view dashboard',
             'generate reports', 'export data',
@@ -301,6 +347,7 @@ class TenantDatabaseSeeder extends Seeder
             'view guest-request', 'create guest-request', 'update guest-request',
             'view daily-report', 'create daily-report',
             'view scanner', 'view transit', 'create transit', 'update transit',
+            'view scan-item', 'update scan-item',
             'access admin panel', 'view dashboard',
             'process check-ins', 'process check-outs',
             'scan meal qr-codes',


### PR DESCRIPTION
## Summary
- add a tenant ScanItemResource so managers can configure scanable access, meal, and consumable items with schedule controls and missed-scan alerts
- introduce the ScanItem model, migration, and seed data to persist schedule metadata and notification preferences
- provide a ScanItemNotificationService to surface notification payloads for upcoming dashboard widgets

## Testing
- php -l app/Filament/Resources/Tenant/ScanItemResource.php
- php -l app/Models/ScanItem.php
- php -l app/Services/ScanItemNotificationService.php
- php -l app/Filament/Resources/Tenant/ScanItemResource/Pages/ListScanItems.php
- php -l app/Filament/Resources/Tenant/ScanItemResource/Pages/CreateScanItem.php
- php -l app/Filament/Resources/Tenant/ScanItemResource/Pages/EditScanItem.php
- php -l database/seeders/TenantDatabaseSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68f37e7ec76083318dab5c343a5393ab