### PR TITLE
Fix missing form property in daily report widget

### DIFF
--- a/app/Filament/Resources/Tenant/DailyReportWidget.php
+++ b/app/Filament/Resources/Tenant/DailyReportWidget.php
@@ -16,6 +16,8 @@ class DailyReportWidget extends Widget
 
     protected static string $view = 'filament.widgets.daily-report-widget';
 
+    public ?Form $form = null;
+
     public ?array $data = [];
 
     public ?string $selectedDate = null;


### PR DESCRIPTION
## Summary
- declare the form property on the daily report widget so Livewire can access it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f39fad1a6483318cf22eb83d0ada90