### PR TITLE
Optimize multi-guest check-in selects for large datasets

### DIFF
--- a/app/Filament/Resources/Tenant/CheckInResource.php
+++ b/app/Filament/Resources/Tenant/CheckInResource.php
@@ -50,7 +50,6 @@ class CheckInResource extends Resource
                             })
                             ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->first_name} {$record->last_name}")
                             ->searchable(['first_name', 'last_name', 'email'])
-                            ->preload()
                             ->required(),
                         Forms\Components\DateTimePicker::make('date_of_arrival')
                             ->required(),
@@ -59,7 +58,6 @@ class CheckInResource extends Resource
                         Forms\Components\Select::make('room_id')
                             ->label('Room')
                             ->relationship('room', 'room_no')
-                            ->preload()
                             ->searchable()
                             ->required()
                             ->helperText('Multiple guests can be checked into the same room'),


### PR DESCRIPTION
## Summary
- stop preloading all guests and rooms on the manual check-in form to avoid loading huge option lists
- replace the multi-guest check-in selects with search-driven lookups that only fetch up to 50 matching guests or rooms at a time
- add helpers to format guest and room labels when presenting search results

## Testing
- php -l app/Filament/Resources/Tenant/CheckInResource.php
- php -l app/Filament/Resources/Tenant/CheckInResource/Pages/MultiGuestCheckIn.php

------
https://chatgpt.com/codex/tasks/task_e_68f3c4551c18833190e8e3bda6dd9608